### PR TITLE
Remove unused content-type.

### DIFF
--- a/src/views/Main.vue
+++ b/src/views/Main.vue
@@ -47,7 +47,6 @@ async function transcribe() {
 
     const res = await Axios.post('https://api.openai.com/v1/audio/transcriptions', formData, {
       headers: {
-        'Content-Type': 'multipart/form-data',
         'Authorization': `Bearer ${import.meta.env.VITE_OPENAI_API_KEY}`,
       }
     })


### PR DESCRIPTION
Qiitaの記事と本レポジトリ、大変参考になりました。

ここで指定している `Content-Type` は実際の通信では使われておらず、http client 側で別の値に上書きされているようです。

<img width="625" alt="image" src="https://user-images.githubusercontent.com/188741/227750188-17a350b4-1ba7-47ee-b681-c52adc3390a2.png">

自分の環境で動かしてみたら headers の `Content-Type` なしで動きました。

参考: https://qiita.com/YOCKOW/items/0b9635c62840998708f7